### PR TITLE
Changed shebangs in .rb files to #!/usr/bin/env ruby

### DIFF
--- a/generateStops.rb
+++ b/generateStops.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'rubygems'
 require 'zipruby'
 require 'csv'

--- a/subway.rb
+++ b/subway.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'csv'
 
 $filename = "stops.csv"


### PR DESCRIPTION
Using /usr/bin/ruby does not work for rvm users.

Using /usr/bin/env causes the shell to search the user's path for ruby and use it.

Search for 'avoid' on http://www.ruby-doc.org/docs/ProgrammingRuby/html/preface.html for more.
